### PR TITLE
Update AT capacities

### DIFF
--- a/config/zones.json
+++ b/config/zones.json
@@ -126,20 +126,21 @@
       ]
     ],
     "capacity": {
-      "biomass": 650,
-      "coal": 225,
+      "biomass": 497,
+      "coal": 0,
       "gas": 4463,
-      "hydro": 7998,
+      "hydro": 8160,
       "hydro storage": 3120,
       "nuclear": 0,
       "oil": 178,
-      "solar": 1193,
-      "wind": 3035,
-      "geothermal": 1,
-      "unknown": 65
+      "solar": 1333,
+      "wind": 3133,
+      "geothermal": 0,
+      "unknown": 273
     },
     "contributors": [
-      "https://github.com/corradio"
+      "https://github.com/corradio",
+      "https://github.com/brandongalbraith"
     ],
     "parsers": {
       "consumption": "ENTSOE.fetch_consumption",


### PR DESCRIPTION
* Update AT capacities

data origin: ENTSOE

Deviations from the ENTSOE data: 
* last remaining coal plant has been shut down, therefore no coal generating capacity.
* "waste", "other", and "other renewable" have been aggregated into "unknown" key